### PR TITLE
Allow namespace customisation and use a designated health check route

### DIFF
--- a/blackbox-exporter.libsonnet
+++ b/blackbox-exporter.libsonnet
@@ -1,7 +1,7 @@
 {
   local blackboxExporter = self,
 
-  name:: error 'must set namespace',
+  name:: error 'must set name',
   namespace:: error 'must set namespace',
   version:: error 'must set version',
   image:: error 'must set image',
@@ -39,6 +39,7 @@
     metadata: {
       labels: blackboxExporter.commonLabels,
       name: blackboxExporter.name,
+      namespace: blackboxExporter.namespace,
     },
     data: {
       'blackbox.yaml': std.manifestJsonEx(blackboxExporter.config, '  '),
@@ -51,6 +52,7 @@
     metadata: {
       labels: blackboxExporter.commonLabels,
       name: blackboxExporter.name,
+      namespace: blackboxExporter.namespace,
     },
     spec: {
       ports: [
@@ -71,6 +73,7 @@
     metadata: {
       labels: blackboxExporter.commonLabels,
       name: blackboxExporter.name,
+      namespace: blackboxExporter.namespace,
     },
     spec: {
       replicas: 1,

--- a/blackbox-exporter.libsonnet
+++ b/blackbox-exporter.libsonnet
@@ -103,7 +103,7 @@
               ],
               readinessProbe: {
                 httpGet: {
-                  path: '/health',
+                  path: '/-/healthy',
                   port: 'http',
                 },
               },


### PR DESCRIPTION
Hello, I've added a few small changes:
* Specify namespace in objects metadata;
* Use a minimal health check that is available in the blackbox_exporter

Hope this helps :smile: 